### PR TITLE
Update DiawiUploader.java

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/diawi/DiawiUploader.java
+++ b/src/main/java/org/jenkinsci/plugins/diawi/DiawiUploader.java
@@ -65,7 +65,7 @@ public class DiawiUploader extends hudson.tasks.Builder implements SimpleBuildSt
 
             DiawiRequest.DiawiJobStatus S = job.getStatus(token);
 
-            int max_trials=30;
+            int max_trials=3000;
             int i=0;
 
             while (S.status ==2001 && i<max_trials)


### PR DESCRIPTION
Upload process needs more check iterations due to the fact that the DIAWI file processing can take up to 1 minute, and only after that the link can be received.